### PR TITLE
Save games to LocalStorage

### DIFF
--- a/web/client/Cargo.toml
+++ b/web/client/Cargo.toml
@@ -16,6 +16,7 @@ reqwasm = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde-wasm-bindgen = "0.4"
+serde_with = "1.13.0"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4"
 wasm-logger = "0.2"

--- a/web/client/near.js
+++ b/web/client/near.js
@@ -13,20 +13,17 @@
 // limitations under the License.
 
 const GAS = "300000000000000";
-const CONTRACT_ID = 'dev-put_your_id_here'
-const NETWORK_ID = 'testnet';
+const CONTRACT_ID = "dev-put_your_id_here";
+const NETWORK_ID = "testnet";
 
-const VIEW_METHODS = [
-  'game_state',
-  'list_games',
-];
+const VIEW_METHODS = ["game_state", "list_games"];
 
 const CHANGE_METHODS = [
-  'new_game',
-  'join_game',
-  'turn',
-  'clear_games',
-  'delete_game',
+  "new_game",
+  "join_game",
+  "turn",
+  "clear_games",
+  "delete_game",
 ];
 
 const ALL_METHODS = VIEW_METHODS.concat(CHANGE_METHODS);
@@ -39,8 +36,8 @@ export class NearWallet {
     const near = new nearApi.Near({
       NETWORK_ID,
       keyStore: new nearApi.keyStores.BrowserLocalStorageKeyStore(),
-      nodeUrl: 'https://rpc.testnet.near.org',
-      walletUrl: 'https://wallet.testnet.near.org',
+      nodeUrl: "https://rpc.testnet.near.org",
+      walletUrl: "https://wallet.testnet.near.org",
     });
 
     // connect to the NEAR Wallet

--- a/web/client/src/board.rs
+++ b/web/client/src/board.rs
@@ -191,7 +191,6 @@ impl Component for Board {
             Msg::Shot(pos) => match ctx.props().side {
                 Side::Local => false,
                 Side::Remote => {
-                    self.grid.cells[pos.y as usize][pos.x as usize].fg = Foreground::Pending;
                     self.game_agent.send(GameMsg::Shot(pos));
                     true
                 }

--- a/web/client/src/game.rs
+++ b/web/client/src/game.rs
@@ -14,7 +14,8 @@
 
 use std::{collections::HashMap, rc::Rc};
 
-use gloo::{dialogs::alert, timers::future::TimeoutFuture};
+use gloo::{dialogs::alert, timers::future::TimeoutFuture, storage::LocalStorage, storage::Storage};
+use serde_with::serde_as;
 use rand::{thread_rng, Rng};
 use reqwasm::http::Request;
 use serde::{Deserialize, Serialize};
@@ -53,8 +54,11 @@ pub enum GameMsg {
     Init,
     Shot(Position),
     WaitTurn,
+    CheckTurn,
+    SaveAndWait,
     ProcessTurn(ContractState),
     UpdateState(String, RoundResult, Position),
+    Resume,
     Error(String),
 }
 
@@ -64,17 +68,21 @@ pub enum HitType {
     Pending,
 }
 
-#[derive(PartialEq, Clone)]
+#[serde_as]
+#[derive(PartialEq, Clone, Serialize, Deserialize)]
 pub struct GameSession {
     pub name: String,
     pub state: GameState,
-    pub contract: Rc<NearContract>,
+    #[serde_as(as = "Vec<(_, _)>")]
     pub local_shots: HashMap<Position, HitType>,
+    #[serde_as(as = "Vec<(_, _)>")]
     pub remote_shots: HashMap<Position, HitType>,
     pub last_receipt: String,
     pub last_shot: Option<Position>,
     pub is_first: bool,
     pub status: String,
+    pub og_until: usize,
+    pub turn_processed: bool,
 }
 
 fn create_random_ships() -> [Ship; 5] {
@@ -131,6 +139,7 @@ pub struct GameProvider {
     _bridge: Box<dyn Bridge<EventBus<GameMsg>>>,
     journal: Dispatcher<EventBus<String>>,
     game: GameSession,
+    contract: Rc<NearContract>,
 }
 
 impl Component for GameProvider {
@@ -142,28 +151,48 @@ impl Component for GameProvider {
             .link()
             .context::<WalletContext>(Callback::noop())
             .unwrap();
-        let state = GameState {
-            ships: ctx.props().ships.clone(),
-            salt: 0xDEADBEEF,
+
+        // check by 'name' for an existing game session in local storage
+        let res: Result<GameSession, _> = LocalStorage::get(ctx.props().name.clone());
+
+        // if we have a game session, set game equal to it or create a new game session
+        let (game_session_exists, game) = match res {
+            Ok(game) => (true,game),
+            Err(_) => (false, GameSession {
+                name: ctx.props().name.clone(),
+                state: GameState {
+                    ships: ctx.props().ships.clone(),
+                    salt: 0xDEADBEEF,
+                },
+                local_shots: HashMap::new(),
+                remote_shots: HashMap::new(),
+                last_receipt: String::new(),
+                last_shot: None,
+                is_first: ctx.props().until == 2,
+                status: format!("Ready!"),
+                og_until: ctx.props().until,
+                turn_processed: false,
+            })
         };
-        let game = GameSession {
-            name: ctx.props().name.clone(),
-            state,
-            contract: wallet.contract.clone(),
-            local_shots: HashMap::new(),
-            remote_shots: HashMap::new(),
-            last_receipt: String::new(),
-            last_shot: None,
-            is_first: ctx.props().until == 2,
-            status: format!("Ready!"),
-        };
-        if ctx.props().until == 1 {
-            ctx.link().send_message(GameMsg::Init);
+
+        // if a game session exists, check who's turn it is and resume the game
+        if game_session_exists {
+            log::info!("Game session exists, checking who's turn it is");
+            ctx.link().send_message(GameMsg::CheckTurn);
+        } else {
+            // if the game session does not exist, initialize the game if player1
+            if ctx.props().until == 1 {
+                log::info!("Game session does not exist, initializing game");
+                ctx.link().send_message(GameMsg::Init);
+            }  
         }
+
+        let contract = wallet.contract.clone();
         GameProvider {
             _bridge: EventBus::bridge(ctx.link().callback(|msg| msg)),
             journal: EventBus::dispatcher(),
             game,
+            contract,
         }
     }
 
@@ -173,6 +202,7 @@ impl Component for GameProvider {
                 self.game.status = format!("Init");
                 let game = self.game.clone();
                 let body = serde_json::to_string(&game.state).unwrap();
+                let contract = self.contract.clone();
                 ctx.link().send_future(async move {
                     let response = match Request::post("/prove/init")
                         .header("Content-Type", "application/json")
@@ -191,73 +221,85 @@ impl Component for GameProvider {
                             return GameMsg::Error(format!("receipt: {}", err));
                         }
                     };
-                    match game.contract.new_game(&game.name, &receipt).await {
-                        Ok(()) => GameMsg::WaitTurn,
+                    match contract.new_game(&game.name, &receipt).await {
+                        Ok(()) => {
+                            log::info!("Game created, save and wait turn {}", game.name);
+                            GameMsg::SaveAndWait
+                        }
                         Err(err) => GameMsg::Error(format!("new_game: {:?}", err)),
                     }
                 });
                 true
             }
             GameMsg::Shot(pos) => {
-                self.game.status = format!("Shot: {}", pos);
-                self.journal.send("GameMsg::Shot".into());
-                self.game.last_shot = Some(pos.clone());
-                self.game.remote_shots.insert(pos.clone(), HitType::Pending);
-                let game = self.game.clone();
-                let is_first = self.game.is_first;
-                self.game.is_first = false;
-                ctx.link().send_future(async move {
-                    if is_first {
-                        let body = serde_json::to_string(&game.state).unwrap();
-                        let response = match Request::post("/prove/init")
-                            .header("Content-Type", "application/json")
-                            .body(body)
-                            .send()
-                            .await
-                        {
-                            Ok(response) => response,
-                            Err(err) => {
-                                return GameMsg::Error(format!("POST /prove/init: {}", err));
+                if self.game.status == "Ready!" {
+                    self.game.status = format!("Shot: {}", pos);
+                    self.journal.send("GameMsg::Shot".into());
+                    self.game.last_shot = Some(pos.clone());
+                    self.game.remote_shots.insert(pos.clone(), HitType::Pending);
+                    let game = self.game.clone();
+                    let contract = self.contract.clone();
+                    let is_first = self.game.is_first;
+                    self.game.is_first = false;
+                    ctx.link().send_future(async move {
+                        if is_first {
+                            let body = serde_json::to_string(&game.state).unwrap();
+                            let response = match Request::post("/prove/init")
+                                .header("Content-Type", "application/json")
+                                .body(body)
+                                .send()
+                                .await
+                            {
+                                Ok(response) => response,
+                                Err(err) => {
+                                    return GameMsg::Error(format!("POST /prove/init: {}", err));
+                                }
+                            };
+                            let receipt = match response.text().await {
+                                Ok(receipt) => receipt,
+                                Err(err) => {
+                                    return GameMsg::Error(format!("receipt: {}", err));
+                                }
+                            };
+                            match contract.join_game(&game.name, &receipt, pos.x, pos.y)
+                                .await
+                            {
+                                Ok(()) => {
+                                    log::info!("Game joined save and wait turn {}", game.name);
+                                    GameMsg::SaveAndWait
+                                }
+                                Err(err) => {
+                                    return GameMsg::Error(format!("join_game: {:?}", err));
+                                }
                             }
-                        };
-                        let receipt = match response.text().await {
-                            Ok(receipt) => receipt,
-                            Err(err) => {
-                                return GameMsg::Error(format!("receipt: {}", err));
-                            }
-                        };
-                        match game
-                            .contract
-                            .join_game(&game.name, &receipt, pos.x, pos.y)
-                            .await
-                        {
-                            Ok(()) => GameMsg::WaitTurn,
-                            Err(err) => {
-                                return GameMsg::Error(format!("join_game: {:?}", err));
+                        } else {
+                            match contract.turn(&game.name, &game.last_receipt, pos.x, pos.y)
+                                .await
+                            {
+                                Ok(()) => {
+                                    log::info!("Turn sent save and and wait turn {}", game.name);
+                                    GameMsg::SaveAndWait
+                                }
+                                Err(err) => {
+                                    return GameMsg::Error(format!("turn: {:?}", err));
+                                }
                             }
                         }
-                    } else {
-                        match game
-                            .contract
-                            .turn(&game.name, &game.last_receipt, pos.x, pos.y)
-                            .await
-                        {
-                            Ok(()) => GameMsg::WaitTurn,
-                            Err(err) => {
-                                return GameMsg::Error(format!("turn: {:?}", err));
-                            }
-                        }
-                    }
-                });
-                true
+                    });
+                    true
+                } else {
+                    alert("Waiting for other player!");
+                    false
+                }
             }
             GameMsg::WaitTurn => {
                 self.game.status = format!("Waiting for other player.");
                 self.journal.send("GameMsg::WaitTurn".into());
-                let until = ctx.props().until as u32;
+                let until = self.game.og_until as u32; //ctx.props().until as u32;
                 let game = self.game.clone();
+                let contract = self.contract.clone();
                 ctx.link().send_future(async move {
-                    let contract_state = match game.contract.get_state(&game.name).await {
+                    let contract_state = match contract.get_state(&game.name).await {
                         Ok(state) => state,
                         Err(err) => {
                             return GameMsg::Error(format!("get_state: {:?}", err));
@@ -290,7 +332,7 @@ impl Component for GameProvider {
                         },
                     );
                 }
-                let until = ctx.props().until;
+                let until = self.game.og_until; //ctx.props().until;
                 ctx.link().send_future(async move {
                     let player = if until == 2 {
                         contract_state.p1
@@ -327,12 +369,52 @@ impl Component for GameProvider {
                 });
                 true
             }
+            GameMsg::CheckTurn => {
+                let until = self.game.og_until as u32; //ctx.props().until as u32;
+                let game = self.game.clone();
+                let contract = self.contract.clone();
+                let turn_processed = self.game.turn_processed;
+                ctx.link().send_future(async move {
+                    let contract_state = match contract.get_state(&game.name).await {
+                        Ok(state) => state,
+                        Err(err) => {
+                            return GameMsg::Error(format!("checkturn get_state: {:?}", err));
+                        }
+                    };
+                    if contract_state.next_turn == until {
+                        // process the turn if it was not processed yet
+                        if !turn_processed { GameMsg::ProcessTurn(contract_state) 
+                        } else {
+                            GameMsg::Resume
+                        }
+                    } else {
+                        TimeoutFuture::new(WAIT_TURN_INTERVAL).await;
+                        GameMsg::WaitTurn
+                    }
+                });
+                true
+            }
             GameMsg::UpdateState(receipt, state, shot) => {
                 self.game.status = format!("Ready!");
                 self.journal.send("GameMsg::UpdateState".into());
                 self.game.state = state.state;
                 self.game.last_receipt = receipt;
                 self.game.local_shots.insert(shot, HitType::Core(state.hit));
+                self.game.turn_processed = true;
+                LocalStorage::set(self.game.name.clone(), self.game.clone()).unwrap();
+                true
+            }
+            GameMsg::SaveAndWait => {
+                log::info!("GameMsg::SaveAndWait {},", self.game.name);
+                self.game.status = format!("Waiting for other player.");
+                self.game.turn_processed = false;
+                LocalStorage::set(self.game.name.clone(), self.game.clone()).unwrap();
+                ctx.link().send_message(GameMsg::WaitTurn);
+                true
+            }
+            GameMsg::Resume => {
+                log::info!("GameMsg::Resume {},", self.game.name);
+                self.game.status = format!("Ready!");
                 true
             }
             GameMsg::Error(msg) => {


### PR DESCRIPTION
Saves games to the browser's local storage so you can leave a game and return to it to continue playing.

The game is saved
- when it is initialized
- when it is joined
- when a turn is taken
- when an opponent's turn is processed
