### PR TITLE
fix: config to optimize build and README instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Launch the web service:
 cargo run --bin battleship-web-server --release
 ```
 
+Install trunk:
+```
+cargo install trunk
+```
+
 Launch the web client:
 ```
 cd web/client

--- a/README.md
+++ b/README.md
@@ -46,11 +46,6 @@ Launch the web service:
 cargo run --bin battleship-web-server --release
 ```
 
-Install trunk:
-```
-cargo install trunk
-```
-
 Launch the web client:
 ```
 cd web/client

--- a/contract/.cargo/config.toml
+++ b/contract/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 target = "wasm32-unknown-unknown"
+
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "link-arg=-s"]

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 arrayref = "0.3"


### PR DESCRIPTION
I don't have the bandwidth to fix the contract compilation from #15/#16, but figured I'd PR in some other quick config things to optimize the build (contract will be a small fraction of the size) and add a missing install instruction (as it was unclear to me) on the way to running into the same issue.

Hopefully this is helpful!